### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Matreshka",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "authors": [
     "finom"
   ],


### PR DESCRIPTION
Исправлена ошибка bower: 
```
bower mismatch      Version declared in the json (1.7.1) is different than the resolved one (1.8.0)
```