### PR TITLE
feat: Adding spaces allowed in parser

### DIFF
--- a/src/parsebindings/_parserdata.js
+++ b/src/parsebindings/_parserdata.js
@@ -33,11 +33,11 @@ calc(parserData, {
     },
     bindingReg: {
         source: ['escLeftBracket', 'escRightBracket'],
-        handler: (left, right) => new RegExp(`${left}(.+?)${right}`, 'g')
+        handler: (left, right) => new RegExp(`${left}\\s*(.+?)\\s*${right}`, 'g')
     },
     strictBindingReg: {
         source: ['escLeftBracket', 'escRightBracket'],
-        handler: (left, right) => new RegExp(`^${left}(.+?)${right}$`, 'g')
+        handler: (left, right) => new RegExp(`^${left}\\s*(.+?)\\s*${right}$`, 'g')
     }
 }, {
     debounceCalc: false // we need to get new regexps immediately when brackets are changed

--- a/test/spec/bindings/bindings_parser_spec.js
+++ b/test/spec/bindings/bindings_parser_spec.js
@@ -24,6 +24,15 @@ describe('Bindings parser', () => {
         expect(node.textContent).toEqual(obj.x);
     });
 
+    it('should parse inner content with spaces', () => {
+        const node = parse('<span>{{  x  }}</span>');
+        const obj = {};
+
+        parseBindings(obj, node, noDebounceFlag);
+        obj.x = 'foo';
+        expect(node.textContent).toEqual(obj.x);
+    });
+
     it('should parse inner content and keep node empty if property value is not given', () => {
         const node = parse('<span>{{x}}</span>');
         const obj = {};


### PR DESCRIPTION
Before that:

```html
<span>{{value}}</span> <!-- correct -->
<span>{{ value }}</span> <!-- doesn't correct -->
<span>{{  value  }}</span> <!-- doesn't correct -->
```

After that:

```html
<span>{{value}}</span> <!-- correct -->
<span>{{ value }}</span> <!-- correct -->
<span>{{  value  }}</span> <!-- correct -->
```